### PR TITLE
Avoid deleting SVG images

### DIFF
--- a/src/Dashboard.php
+++ b/src/Dashboard.php
@@ -238,7 +238,7 @@ class Dashboard {
         // check each size
         foreach ($Meta['sizes'] as $Key => $SizePack) {
 
-            if (!in_array($Key, $HandleSizes)) {
+            if (!in_array($Key, $HandleSizes) || $SizePack['mime-type'] === 'image/svg+xml') {
                 continue; // keep that image-size
             }
 


### PR DESCRIPTION
To avoid conflicts with plugins adding SVG support to WordPress (e.g. [SVG Support](https://de.wordpress.org/plugins/svg-support/))

fixes #1