### PR TITLE
Add 'fws_rod_sizes' filter for programmatically determined ROD sizes

### DIFF
--- a/src/Hooks.php
+++ b/src/Hooks.php
@@ -134,7 +134,8 @@ class Hooks {
 
         if (self::$SizesToHandle === null) {
             $Options = Config::Get();
-            self::$SizesToHandle= $Options['HandleSizes'];
+            $ProgrammaticSizes = apply_filters('fws_rod_sizes', []);
+            self::$SizesToHandle = array_unique(array_merge($Options['HandleSizes'], $ProgrammaticSizes));
         }
         return self::$SizesToHandle;
     }

--- a/src/templates/settings.php
+++ b/src/templates/settings.php
@@ -6,7 +6,9 @@
     $OptionName= \FWS\ROD\Dashboard::$OptionName;
     $RedirectURL= urlencode($_SERVER['REQUEST_URI']);
     $CurrSettings= unserialize(get_option($OptionName)) ?? [];
-    $CurrSettings['HandleSizes']= $CurrSettings['HandleSizes'] ?? [];
+    $ProgrammaticSizes= apply_filters('fws_rod_sizes', []);
+    $ManualSizes= $CurrSettings['HandleSizes'] ?? [];
+    $CurrSettings['HandleSizes']= array_unique(array_merge($ManualSizes, $ProgrammaticSizes));
 ?>
 <style>
     .fws_rod h1 {
@@ -34,7 +36,11 @@
     }
     .fws_rod form table th {
         text-align: right;
+        vertical-align: top;
         width: 3em;
+    }
+    .fws_rod form table th input[type="checkbox"] {
+        margin-top: 1px;
     }
     .fws_rod form table span {
         color: gray;
@@ -54,8 +60,14 @@
         <tr>
             <?php $Description= $Size['width'].' x '.$Size['height'].($Size['crop'] ? ', crop' : ''); ?>
             <?php $Checked= in_array($Key, $CurrSettings['HandleSizes']) ? ' checked' : ''; ?>
-            <th><input type="checkbox" name="fws_ROD_Sizes[]" id="<?php echo esc_attr($Key);?>" value="<?php echo esc_attr($Key);?>"<?php echo $Checked; ?>></th>
-            <td><label for="<?php echo esc_attr($Key);?>"><b><?php echo esc_html($Key);?></b><span>(<?php echo esc_html($Description);?>)</span></label></td>
+            <?php $Disabled= in_array($Key, $ProgrammaticSizes) ? ' disabled' : ''; ?>
+            <th><input type="checkbox" name="fws_ROD_Sizes[]" id="<?php echo esc_attr($Key);?>" value="<?php echo esc_attr($Key);?>"<?php echo $Checked; ?><?php echo $Disabled; ?>></th>
+            <td>
+                <label for="<?php echo esc_attr($Key);?>"><b><?php echo esc_html($Key);?></b><span>(<?php echo esc_html($Description);?>)</span></label>
+                <?php if (in_array($Key, $ProgrammaticSizes)): ?>
+                    <p><em>This size has been enabled programmatically and can therefore not be disabled.</em></p>
+                <?php endif ?>
+            </td>
         </tr>
         <?php } ?>
     </table>


### PR DESCRIPTION
This PR adds a `fws_rod_sizes` filter to collect programmatically determined ROD image sizes. This is useful for highly customized themes which add their own image sizes for their features and want them to always be resize on demand.

---

<details>
<summary><strong>Background for our personal use case</strong></summary>

Maybe some background that inspired this feature:

We made a custom hero element (for a visual page builder, not unlike Gutenberg) which naturally has quite some large image sizes, and also has all the same sizes again for retina screens in 2x resolution. Only a handful of images are ever used as hero images, but _all_ images are resized by WordPress, which is not only a disk space issue but at some point becomes a performance problem when uploading images as well.

That's when we discovered this plugin.

However, since the image sizes used for the hero element are completely abstracted away from the WordPress user, it would not make a lot of sense to have them manually declare these image sizes as request-on-demand in the plugin settings – therefore a programmatic way of declaring those sizes as ROD would be massively useful.

</details>

---

Usage:
```php
// PHP ≥ 7.4
add_filter('fws_rod_sizes', fn ($sizes) => ['medium', ...$sizes]);


// PHP < 7.4
add_filter('fws_rod_sizes', function ($sizes) {
    return array_merge($sizes, ['medium']);
});
```

Manually selected ROD image sizes are added _after_ the filter runs, so the filter can _not_ disable manually selected image sizes.

Sizes added by the filter naturally can not be manually _unselected_ in the plugin settings though, therefore an according hint is shown:

![FWS Resize-on-demand settings showing a disabled checked checkbox for image sizes added programmatically](https://user-images.githubusercontent.com/1922624/142594659-56c87c6e-5da8-4408-bafe-cc5c13f34d0f.png)

closes #2