### PR TITLE
Add compatibility with 'Regenerate Thumbnails' plugin

### DIFF
--- a/src/Compatibility.php
+++ b/src/Compatibility.php
@@ -11,6 +11,7 @@ class Compatibility {
     protected static $Patches= [
         'wpGraphQL',
         'ACF',
+        'RegenerateThumbnails'
     ];
 
 
@@ -71,4 +72,13 @@ class Compatibility {
         }, 9, 3);
     }
 
+    /**
+     * Compatibility solution for Regenerate Thumbnails plugin.
+     * Prevents missing thumbnails from being generated when handled by this plugin.
+     */
+    protected static function RegenerateThumbnails() {
+        add_filter('regenerate_thumbnails_missing_thumbnails', function($sizes, $fullsize_metadata = [], $_instance = null) {
+            return Hooks::DisableSizes($sizes, $fullsize_metadata);
+        });
+    }
 }


### PR DESCRIPTION
> Sorry for spamming your repo with PRs, but I'm finding tiny spaces for improvement here and there. 😁 
> Please give me a warning if I'm overwhelming you or exceeding the scope of the plugin!

This PR adds compatibility with the hugely popular [Regenerate Thumbnails](https://de.wordpress.org/plugins/regenerate-thumbnails/) plugin.

By default, Regenerate Thumbnails will create every image size defined (which of course counters the exact point of this plugin), but luckily it provides a filter to remove image sizes from its regeneration list, which we can hook into.