### PR TITLE
fix exception due to 'protected' method when uploading images

### DIFF
--- a/src/Services.php
+++ b/src/Services.php
@@ -27,7 +27,7 @@ class Services {
      *
      * @return array
      */
-    protected static function GetSizesToHandle() {
+    public static function GetSizesToHandle() {
 
         if (self::$SizesToHandle === null) {
             // get from configuration


### PR DESCRIPTION
🚨  Emergency fix coming your way.

😁

You had a [tiny little bug](https://github.com/tekod/fws-resize-on-demand/commit/d1443881581b4f4c9c0bc97e72c4467b7a4445e2#diff-9ed2b93fa9e08cdce5c86e3e009e739ee85ff05dc8c4767dc2cefeec3af1e38bR148) in your last commit, leading to the plugin not working at all: The `Services::GetSizesToHandle()` method is protected, but is called from the `Hooks` class, leading to an exception being thrown which aborts the process of filtering images to resize.
