### PR TITLE
Prevent fatal error when initially activating the plugin

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -28,7 +28,7 @@ class Config {
     public static function Init() {
 
         // load from "options" table
-        $Settings= unserialize(get_option(self::$OptionName)) ?? [];
+        $Settings= unserialize(get_option(self::$OptionName)) ?: [];
 
         // set settings
         self::Set($Settings);


### PR DESCRIPTION
Another tiny fix:

The plugin currently fails to be activated when installed into a new project.
This is because it initially trys to unserialize the `fws_resize_on_demand` option and uses an empty array `[]` as  a fallback value.

However, the fallback value is implemented via the null coalescing operator `??`. This operator is not triggered when the option is still missing as `unserialize(get_option(self::$OptionName))` returns `false` in that case.
This results in the `false` value being used as the `$Settings` (instead of an array), leading to a fatal "Unsupported operand types" error in the process when the `false` is combined with the default settings via the `+` operator.

This PR solves this by replacing the `??` operator with the `?:` operator, thus applying to falsy values. 🙂 