### PR TITLE
Skip invalid attachments

### DIFF
--- a/src/Hooks.php
+++ b/src/Hooks.php
@@ -52,6 +52,11 @@ class Hooks {
             return false;
         }
 
+        // Skip if $Id does not refer to a valid attachment
+        if ($ImageData === false) {
+            return false;
+        }
+
         // resize now
         return self::Resize($ImageData, $Id, $Size);
     }


### PR DESCRIPTION
Another fix, although this was kind of a lucky shot by me: In our codebase, there was an invalid attachment ID (somebody passed a full image URL to the `wp_get_attachment_image ()` function). WordPress fails silently with this, and so should the ROD plugin.

This PR makes the plugin skip resizing an image if resolving the attachment ID does not yield any image data.