### PR TITLE
Prevent notice error when resizing to specific pixel size array

### DIFF
--- a/src/Hooks.php
+++ b/src/Hooks.php
@@ -28,7 +28,10 @@ class Hooks {
      */
     public static function OnImageDownsize($Out, $Id, $Size) {
 
-        Services::Log("OnImageDownsize: id:$Id -> '$Size' size.");
+        Services::Log(sprintf(
+            "OnImageDownsize: id:$Id -> %s size.",
+            var_export($Size, true)
+        ));
 
         // skip if already resolved by previous filter
         if ($Out !== false) {


### PR DESCRIPTION
This is a rather simple one: In a case where somebody passes a concrete width/height array instead of a size name into the `wp_get_attachment_image()` function, the debug logs produce a notice (because they try to convert that object into a string).

Passing an array is handled properly by the plugin, it's just the new debug logs that fail here.