### PR TITLE
re-establish compatibility with the Regenerate Thumbanils plugin

### DIFF
--- a/src/Compatibility.php
+++ b/src/Compatibility.php
@@ -79,7 +79,7 @@ class Compatibility {
     protected static function RegenerateThumbnails() {
 
         add_filter('regenerate_thumbnails_missing_thumbnails', function($sizes, $fullsize_metadata = [], $_instance = null) {
-            return Hooks::DisableSizes($sizes, $fullsize_metadata);
+            return Hooks::RemoveSizesFromAutoResizing($sizes, $fullsize_metadata);
         });
     }
 


### PR DESCRIPTION
Hi again 😁 
The compatibility with the Regenerate Thumbnails plugin broke (quite a while ago already) in [`d144388`](https://github.com/tekod/fws-resize-on-demand/commit/d1443881581b4f4c9c0bc97e72c4467b7a4445e2#diff-9ed2b93fa9e08cdce5c86e3e009e739ee85ff05dc8c4767dc2cefeec3af1e38b), because the `Hooks::DisableSizes` method was renamed.

This PR makes the Regenerate Thumbnails hook use the correct, changed name.