### PR TITLE
Avoid overriding previously generated image sizes

### DIFF
--- a/src/Hooks.php
+++ b/src/Hooks.php
@@ -115,7 +115,7 @@ class Hooks {
      * @param array $SizeData
      * @return array|false
      */
-    protected static function ResizeSingleImage($ImageData, $Id, $SizeName, $SizeData) {
+    protected static function ResizeSingleImage(&$ImageData, $Id, $SizeName, $SizeData) {
 
         // make the new thumb
         $Resized = image_make_intermediate_size(


### PR DESCRIPTION
Hey Miro, found another tiny bug we introduced by resizing `@2x` sizes. 😁 

Calling the `ResizeSingleImage` method multiple times overrides the image metadata the results of the respective previous image size, resulting in the `@2x` sizes never being stored in the database as they are immediately being overriden by the base size right after.

I solved this the quite inelegant way (passing the `$ImageData` to `ResizeSingleImage` by reference). This does the trick, but if you dislike it I could alternatively refactor the return value of `ResizeSingleImage` and merge the new image sizes back into the original one.